### PR TITLE
Fix auto port detection based on device name

### DIFF
--- a/nanoKONTROL.py
+++ b/nanoKONTROL.py
@@ -1173,11 +1173,11 @@ def auto_connect(force=False):
     if not force and midi_dest_port.get() and midi_source_port.get():
         return
     for name in destination_ports:
-        if name.startswith("nanoKONTROL"):
+        if "nanoKONTROL" in name:
             midi_dest_port.set(name)
             break
     for name in source_ports:
-        if name.startswith("nanoKONTROL"):
+        if "nanoKONTROL" in name:
             midi_source_port.set(name)
             break
     source_changed()


### PR DESCRIPTION
The code didn't worked as it because I'm using [a2j](https://github.com/jackaudio/a2jmidid) to expose Alsa devices in Jack environment. The device name is in that case `a2j:nanoKONTROL [20] (playback): nanoKONTROL nanoKONTROL _ CTRL` 

Please accept this PR then eventually add some code on top of this commit

Thanks !